### PR TITLE
Fix problematic ESM import statements

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -11,4 +11,4 @@ esbuild.buildSync({
     keepNames: true,
     format: 'cjs',
     bundle: true
-})
+});

--- a/index.mjs
+++ b/index.mjs
@@ -1,2 +1,7 @@
-import * as AIHorde from './index.js'
-export default { AIHorde };
+import * as lib from "./index.js";
+
+export * from "./index.js";
+// Provide everything as an object because there is a
+// `module.exports = { ... }` statement at the end of
+// the "./index.js"` file.
+export default lib;


### PR DESCRIPTION
<!-- Replace [Title] with a short summary of what this pull request is -->
# Fix problematic ESM import statements

<!-- If you need help add the `help-wanted` label -->

## Detailed Description

This PR addresses the issue described in #13 by properly re-exporting everything from the `index.js` file via the `export * from "..."` syntax. It also provides a default export containing all the library's exports from `index.js` because that seems to be the default behavior.

<!-- Please provide a detailed description on what exactly this pull request adds or changes -->

## Why this is needed

_Because it fixes #13_.
